### PR TITLE
Added WiringPi/wiringPi to extension include dirs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ _wiringpi2 = Extension(
         'WiringPi/wiringPi/wiringShift.c',
 		'wiringpi_wrap.c'
     ],
+    include_dirs=["WiringPi/wiringPi"],
 )
 
 setup(


### PR DESCRIPTION
Didn't compile without this addition on the latest raspbian image.

Please merge it in
