### PR TITLE
Use swig if available, but package wiringpi_wrap.c in the source dist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,5 @@ include LICENSE.txt
 include bindings.i
 include constants.py
 include wiringpi-class.py
+include wiringpi.i
+include wiringpi_wrap.c


### PR DESCRIPTION
This is one way to make the pypi source dist as easily installed as possible (won't require swig) while still rebuilding from source as much as possible when building the package.