### PR TITLE
Changing the protcol of submodule from HTTP to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "WiringPi"]
 	path = WiringPi
-	url = http://github.com/wiringPi/WiringPi
+	url = https://github.com/wiringPi/WiringPi


### PR DESCRIPTION
I changed the protcol of submodule from HTTP to HTTPS because downloading the submodule "WiringPi" fails via http.